### PR TITLE
[DJ-2212] Allow External Redirects

### DIFF
--- a/lib/ae_reverse_proxy/controller_callback_method.rb
+++ b/lib/ae_reverse_proxy/controller_callback_method.rb
@@ -41,7 +41,7 @@ module AeReverseProxy
             redirect_uri.port = request.port
           end
 
-          redirect_to redirect_uri.to_s, status: code
+          redirect_to redirect_uri.to_s, status: code, allow_other_host: true
           return
         end
 


### PR DESCRIPTION
Previously, screenings_app would frequently trigger an `UnsafeRedirectError` after the Rails 7.1 upgrade. It was found that this happens starting in Rails 7, where `config.action_controller.raise_on_open_redirects` was set by default to be true.

JIRA card: https://appfolio.atlassian.net/browse/DJ-2212
related: https://appfolio.atlassian.net/browse/DJ-2174