### PR TITLE
[BANK-2106] Migrate gem source from RubyGems to JFrog

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   gem-tool: appfolio/gem-tool@volatile
+  public-packages: https://raw.githubusercontent.com/appfolio/public-packages/v1/orbs/public-packages.yml
 
 workflows:
   rc:
@@ -9,6 +10,8 @@ workflows:
       - gem-tool/rake_test:
           name: test_ruby-<< matrix.ruby_version >>
           executor_tag: ruby
+          after-checkout-steps:
+            - public-packages/setup
           matrix:
             parameters:
               ruby_version:

--- a/Appraisals
+++ b/Appraisals
@@ -2,13 +2,13 @@
 
 if Gem::Requirement.new(['>= 3.3', '< 4.1']).satisfied_by?(Gem::Version.new(RUBY_VERSION))
   appraise "ruby-#{RUBY_VERSION}_rack2" do
-    source 'https://rubygems.org' do
+    source 'https://appfolio.jfrog.io/artifactory/api/gems/appfolio-ae_reverse_proxy-gem/' do
       gem 'rack', '~> 2.2'
     end
   end
 
   appraise "ruby-#{RUBY_VERSION}_rack3" do
-    source 'https://rubygems.org' do
+    source 'https://appfolio.jfrog.io/artifactory/api/gems/appfolio-ae_reverse_proxy-gem/' do
       gem 'rack', '~> 3.0'
     end
   end

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-source 'https://rubygems.org' # global source
+source 'https://appfolio.jfrog.io/artifactory/api/gems/appfolio-ae_reverse_proxy-gem/' # global source
 
-source 'https://rubygems.org' do
+source 'https://appfolio.jfrog.io/artifactory/api/gems/appfolio-ae_reverse_proxy-gem/' do
   gem 'appraisal', '>= 2.5', '< 3'
   gem 'bundler', '>= 2.6', '< 5'
   gem 'debug', '>= 1.10', '< 2'


### PR DESCRIPTION
## Summary
Migrate Ruby gem source from rubygems.org to JFrog as part of org-wide JFrog migration.

## Changes
- Replaced `source 'https://rubygems.org'` with JFrog URL in Gemfile
- Replaced `source 'https://rubygems.org'` with JFrog URL in Appraisals
- Updated `allowed_push_host` in ae_reverse_proxy.gemspec to JFrog URL
- Updated `appfolio.com/package-location` in catalog-info.yaml to JFrog URL
- Added `public-packages` orb and `after_checkout_steps` to .circleci/config.yml
- Created .github/dependabot.yaml with JFrog registry configuration

## Why
AppFolio is migrating from RubyGems.org to JFrog for Ruby dependency installation.
Jira Issue: https://appfolio.atlassian.net/browse/BANK-2106

## Test Plan
- CI passes with the new gem source configuration